### PR TITLE
Update edit link pattern in VitePress config

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -82,7 +82,7 @@ export default defineConfig({
   themeConfig: {
     logo: '/logo.svg',
     editLink: {
-      pattern: 'https://github.com/toreis-up/slidev-docs-ja/edit/main/:path',
+      pattern: 'https://github.com/slidevjs/docs-ja/edit/main/:path',
       text: 'このページの変更を提案する',
     },
 


### PR DESCRIPTION
I had created the edit proposal link assuming a personal host.
I have changed it to reference this repository.

編集提案リンクを個人ホスト前提で作成していました。
この Repository を参照するように変更しました。
